### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/alvinveroy/VoiceCast/security/code-scanning/1](https://github.com/alvinveroy/VoiceCast/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow. This is best done at the workflow root level (just below the `name:` declaration), ensuring it applies to all jobs unless overridden. For the shown workflow, the only apparent requirement is to read repository contents, which means `contents: read` is the safest minimal setting. This will prevent jobs from having unnecessary write access to repository resources. No other permissions, imports, methods, or definitions need to be changed, as this only involves editing the YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
